### PR TITLE
Migrate from bintray to Github packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 *.ipr
 .idea
 *.bak
+
+.envrc

--- a/README.md
+++ b/README.md
@@ -29,13 +29,39 @@ password = karaf
 
 Add the guanaco-io/alerta dependency to your project.
 eg using maven:
+
+Update `~/.m2/settings.xml` and add your Github login info:
+```xml
+<settings>
+    ...
+  <servers>
+    <server>
+      <id>github</id>
+      <username>USERNAME</username>
+      <password>TOKEN</password>
+    </server>
+  </servers>
+    
+</settings>
+```
+More info about this on [Configuring Apache Maven for use with GitHub Packages
+](https://docs.github.com/en/packages/guides/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages)
+
+Add the repository:
+
 ```xml
 <repositories>
     <repository>
-        <id>bintray-guanaco-io-maven</id>
-        <url>https://dl.bintray.com/guanaco-io/maven/</url>
+        <id>github</id> <!-- this should equal the server id in setting.xml -->
+        <url>https://maven.pkg.github.com/guanaco-io/alerta</url>
     </repository>
 </repositories>
+```
+
+And add the dependencies:
+
+```xml
+
 
 <dependency>
     <groupId>io.guanaco.alerta</groupId>

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")

--- a/release.md
+++ b/release.md
@@ -10,17 +10,18 @@ sbt:alerta>+ publishM2
 
 ## Remote
 
-Create a credentials file `${user.home}/.bintray/.credentials` and provide the correct data:
+This project uses GitHub Package Repository. In order to deploy a version of the packages, you need to set up a personal access token with `repo` and the three `*:packages` scopes.
+Cfr. [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more information on how to do that.
 
-```properties
-realm=Bintray API Realm @ api.bintray.com
-host=api.bintray.com
-user=<username>
-password=<api-key>
+Afterwards, make sure the access token is available in the `GITHUB_TOKEN` environment variable (we recommend using [direnv](https://direnv.net/)).
 
-```
+See https://github.com/djspiewak/sbt-github-packages for additional authentication options to the Github Package Repository.
 
-Publish all supported scala versions to the repo (only release versions are allowed):
+Building and deploying a release:
+
+* run the `./release.sh <version>` script to create the release tag
+* checkout the release tag: `git checkout release-<version>`
+* run the release build to with
 ```sbtshell
-sbt:alerta>+ publish
+sbt:alerta>+ clean test publish
 ```


### PR DESCRIPTION
The sun has set for the Bintray repository, so this PR migrates to Github Packages.